### PR TITLE
flush persistant data

### DIFF
--- a/asset_generator/core/asset_extractor.py
+++ b/asset_generator/core/asset_extractor.py
@@ -113,7 +113,7 @@ class AssetExtractor(BaseExtractor):
 
         """
         processor = self._load_processor(source_media)
-
+        # get asset values from media handler
         data = processor.run(filepath, source_media, checksum, **kwargs)
 
         # Get dataset description file
@@ -123,7 +123,7 @@ class AssetExtractor(BaseExtractor):
             categories = self.get_categories(filepath, source_media, description)
             data['body']['categories'] = categories
 
-            # Get facet values
+            # Get facet values from extraction methods
             processor_output = self.run_processors(filepath, description, source_media, **kwargs)
             properties = processor_output.get('properties', {})
 

--- a/asset_generator/media_handlers/object_store_handler.py
+++ b/asset_generator/media_handlers/object_store_handler.py
@@ -70,6 +70,7 @@ class ObjectStoreHandler(BaseMediaHandler):
         """
 
         LOGGER.info(f'Extracting metadata for: {path} with checksum: {checksum}')
+        self.info = {}
 
         uri_parse = kwargs.get('uri_parse')
         if not uri_parse:


### PR DESCRIPTION
`self.info` remained persistent through each run of the media handler. Flush the data at the start of the run.